### PR TITLE
Default encoder now excludes Option.None instead of "key":null

### DIFF
--- a/featherbed-circe/src/main/scala/featherbed/circe/package.scala
+++ b/featherbed-circe/src/main/scala/featherbed/circe/package.scala
@@ -10,9 +10,11 @@ import shapeless.Witness
 
 package object circe {
 
+  private val printer = Printer.noSpaces.copy(dropNullKeys = true)
+
   implicit def circeEncoder[A : Encoder] : content.Encoder[A, Witness.`"application/json"`.T] =
     content.Encoder.of("application/json") {
-      (value: A, charset: Charset) => content.Encoder.encodeString(value.asJson.toString, charset)
+      (value: A, charset: Charset) => content.Encoder.encodeString(printer.pretty(value.asJson), charset)
     }
 
   implicit def circeDecoder[A : Decoder] : content.Decoder.Aux[Witness.`"application/json"`.T, A] =


### PR DESCRIPTION
By default, when JSON-encoding case classes, circe encodes Options like `case class MyClass(one:String, two:Option[String]); MyClass("myval", None)` as `{ "one":"myval", "two":null }`

Now, by default featherbed will encode it as `{ "one":"myval" }` and exclude the None. This makes more sense for a JSON API client, where Option case class values probably represent optional API keys.